### PR TITLE
Add double pattern matching support + more tests

### DIFF
--- a/rubban/autoindexpattern.go
+++ b/rubban/autoindexpattern.go
@@ -177,15 +177,21 @@ func buildIndexPattern(generalPattern GeneralPattern, unmatchedIndex string) str
 	newIndexPattern := generalPattern.Pattern
 	/// Start from 1 to escape first match group which is the whole string.
 	for i := 1; i < len(matchGroups); i++ {
+		var match bool
 		for _, matchGroup := range generalPattern.matchGroups {
 			if matchGroup == i {
-				// This is a match Group
-				newIndexPattern = strings.Replace(newIndexPattern, "*", matchGroups[i], 1)
-			} else {
-				// This is a wildcard (make it ? for now) (yes there can be a more efficient logic for that.)
-				newIndexPattern = strings.Replace(newIndexPattern, "*", "?", 1)
+				match = true
 			}
 		}
+
+		if match {
+			// This is a match Group
+			newIndexPattern = strings.Replace(newIndexPattern, "*", matchGroups[i], 1)
+		} else {
+			// This is a wildcard (make it ? for now) (yes there can be a more efficient logic for that.)
+			newIndexPattern = strings.Replace(newIndexPattern, "*", "?", 1)
+		}
+
 	}
 	newIndexPattern = strings.Replace(newIndexPattern, "?", "*", -1)
 	return newIndexPattern

--- a/rubban/autoindexpattern.go
+++ b/rubban/autoindexpattern.go
@@ -153,7 +153,7 @@ func (b *rubban) getIndexPattern(generalPattern GeneralPattern, computedIndexPat
 
 	if len(patternsList) > 0 {
 		matchedIndicesRegx = regexp.MustCompile(strings.Join(patternsList, "|"))
-	}else{
+	} else {
 		// If no PatternList that means that the first time to encounter this pattern. So we won't match anything.
 		matchedIndicesRegx = regexp.MustCompile("$.")
 	}
@@ -195,10 +195,10 @@ func getMatchGroups(pattern string) []int {
 	groups := make([]int, 0)
 	group := 1
 	for _, char := range pattern {
-		if char == 63 {
+		if char == '?' {
 			groups = append(groups, group)
 			group++
-		} else if char == 42 {
+		} else if char == '*' {
 			group++
 		}
 	}

--- a/rubban/autoindexpattern_test.go
+++ b/rubban/autoindexpattern_test.go
@@ -64,10 +64,10 @@ func TestAutoindexPatternMatchers(t *testing.T) {
 		},
 		{
 			generalPattern:        "?-*",
-			indices:               []kibana.Index{{Name: "fooaa2020.02.14"}, {Name: "-cool-index-"}, {Name: ".kibana"}, {Name: "test----aabcc2020.02.14"}},
+			indices:               []kibana.Index{{Name: "-cool-index-"}, {Name: ".kibana"}, {Name: "test----aabcc2020.02.14"}},
 			indexpatterns:         []kibana.IndexPattern{},
-			expectedIndexPatterns: []string{"test-*"},
-			tcaseName:             `random gibberish that should not match most of the time besides the last one`,
+			expectedIndexPatterns: []string{"test-*", "-*", "*-*"},
+			tcaseName:             `random gibberish that should not match most of the time besides two`,
 		},
 		{
 			generalPattern:        "?-?-*",


### PR DESCRIPTION
Hi! It's me again. :smile: This PR:
* Adds double matcher (probably it supports even more now) support
* Improves the tests by breaking them into separate cases with `t.Run` + properly checking if the resulting index patterns really match (we were missing comparison of `len`)
* Adds handling for the case when nothing matches so that we wouldn't add index patterns like `*-*` which don't make much sense
* Converts one place into proper characters instead of comparing them with numbers

I have tested with the improved test coverage. The logic in that function is a bit complicated so I'm not sure if this is what we want but please do take a look. At least it seems like it is working properly from the behavior's perspective.

This is needed for me because our ELK deployment uses the pattern `$team_name-$application_name-$date` :smile: 